### PR TITLE
Fix ModUpdater Config

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,7 +27,7 @@
     "modupdater": {
       "strategy": "github",
       "owner": "Scotsguy",
-      "repo": "potion-of-get-his-ass"
+      "repository": "potion-of-get-his-ass"
     }
   }
 }


### PR DESCRIPTION
```repo``` was changed to ```repository``` for consistency with the Maven strategy.